### PR TITLE
Reset indexes and buffers on `setup`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descript/kali",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "license": "LGPL",
   "author": "Vivek Panyam <viv.panyam@gmail.com>",
   "main": "./dist/index.js",

--- a/src/Kali.ts
+++ b/src/Kali.ts
@@ -256,6 +256,11 @@ class Kali {
   static overlapsDiv: Double[] = [6.833, 7, 2.5, 2];
   static searchesDiv: Double[] = [5.587, 6, 2.14, 2];
 
+  public reset() {
+    this.t.inputFifo.clear();
+    this.t.outputFifo.clear();
+  }
+
   public setup(
     sampleRate: Double,
     factor: Double, // Factor to change tempo by
@@ -265,6 +270,7 @@ class Kali {
     overlapMs: Double | null = null,
   ): void {
     const profile = 1;
+    this.reset();
     const t = this.t;
     t.sampleRate = sampleRate;
 

--- a/src/Kali.ts
+++ b/src/Kali.ts
@@ -257,8 +257,14 @@ class Kali {
   static searchesDiv: Double[] = [5.587, 6, 2.14, 2];
 
   public reset() {
-    this.t.inputFifo.clear();
-    this.t.outputFifo.clear();
+    const t = this.t;
+    t.inputFifo.clear();
+    t.outputFifo.clear();
+    t.segmentsTotal = 0;
+    t.samplesOut = 0;
+    if (t.overlapBuf) {
+      t.overlapBuf.fill(0);
+    }
   }
 
   public setup(


### PR DESCRIPTION
This addresses an issue where re-using a `Kali` object (i.e., calling `setup` again) is not equivalent to creating a new one. 

We want to re-use the object to avoid having to allocate new buffers.