### PR TITLE
Unconditionally call reserve on inputFifo in setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descript/kali",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "license": "LGPL",
   "author": "Vivek Panyam <viv.panyam@gmail.com>",
   "main": "./dist/index.js",

--- a/src/Kali.ts
+++ b/src/Kali.ts
@@ -323,10 +323,7 @@ class Kali {
 
     const maxSkip = handleInt(Math.ceil(factor * (t.segment - t.overlap)));
     t.processSize = Math.max(maxSkip + t.overlap, t.segment) + t.search;
-    if (!t.isInitialized) {
-      t.inputFifo.reserve(handleInt(t.search / 2));
-    }
-
+    t.inputFifo.reserve(handleInt(t.search / 2));
     t.isInitialized = true;
   }
 


### PR DESCRIPTION
This will ensure that new Kali(1) and calling `setup` again on an existing Kali instance will have the same behavior.