### PR TITLE
Reset `samplesIn` in `reset`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@descript/kali",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "license": "LGPL",
   "author": "Vivek Panyam <viv.panyam@gmail.com>",
   "main": "./dist/index.js",

--- a/src/Kali.ts
+++ b/src/Kali.ts
@@ -261,6 +261,7 @@ class Kali {
     t.inputFifo.clear();
     t.outputFifo.clear();
     t.segmentsTotal = 0;
+    t.samplesIn = 0;
     t.samplesOut = 0;
     if (t.overlapBuf) {
       t.overlapBuf.fill(0);


### PR DESCRIPTION
The reset function should also reset `samplesIn`, like it does for `samplesOut`. The result of not doing this can lead to massive allocations/slow loops in `flush()` if you're re-using the same Kali instance (but resetting/calling "setup" again). 